### PR TITLE
Changed link to apto repository

### DIFF
--- a/new_apto
+++ b/new_apto
@@ -1,6 +1,6 @@
 [submodule "libs/apto"]
 	path = libs/apto
-	url = git://programerror.com/apto.git
+	url = https://github.com/dmbryson/apto.git
 [submodule "documentation"]
 	path = documentation
 	url = https://github.com/devosoft/avida.wiki.git


### PR DESCRIPTION
Old URL points to programerror.com/apto.git, which no longer works.  I switched it to the GitHub version, https://github.com/dmbryson/apto.git.