### PR TITLE
Migrate testrunner from Python 2 to Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,209 @@ install_manifest.txt
 wbuild
 DerivedData
 
+# Created by https://www.toptal.com/developers/gitignore/api/c++,python
+# Edit at https://www.toptal.com/developers/gitignore?templates=c++,python
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# End of https://www.toptal.com/developers/gitignore/api/c++,python

--- a/avida-core/tests/_testrunner/dircache.py
+++ b/avida-core/tests/_testrunner/dircache.py
@@ -1,0 +1,41 @@
+# adapted from Python2.7 source
+# Copyright (c) 2001-2020 Python Software Foundation; All Rights Reserved
+
+"""Read and cache directory listings.
+
+The listdir() routine returns a sorted list of the files in a directory,
+using a cache to avoid reading the directory more often than necessary.
+The annotate() routine appends slashes to directories."""
+
+import os
+
+__all__ = ["listdir", "opendir", "annotate", "reset"]
+
+cache = {}
+
+def reset():
+    """Reset the cache completely."""
+    global cache
+    cache = {}
+
+def listdir(path):
+    """List directory contents, using cache."""
+    try:
+        cached_mtime, list = cache[path]
+        del cache[path]
+    except KeyError:
+        cached_mtime, list = -1, []
+    mtime = os.stat(path).st_mtime
+    if mtime != cached_mtime:
+        list = os.listdir(path)
+        list.sort()
+    cache[path] = mtime, list
+    return list
+
+opendir = listdir # XXX backward compatibility
+
+def annotate(head, list):
+    """Add '/' suffixes to directories."""
+    for i in range(len(list)):
+        if os.path.isdir(os.path.join(head, list[i])):
+            list[i] = list[i] + '/'

--- a/avida-core/tests/_testrunner/testrunner.py
+++ b/avida-core/tests/_testrunner/testrunner.py
@@ -935,7 +935,7 @@ def runConsistencyTests(alltests, dolongtests):
 
     if len(tests) == 0:
         print "No Consistency Tests Available (or Specified)."
-        return (0, 0)
+        return (0, 0, 0)
 
     print "\nRunning Consistency Tests:\n"
 
@@ -994,7 +994,7 @@ def runPerformanceTests(alltests, dolongtests, force, saveresults):
 
     if len(tests) == 0:
         print "No Performance Tests Available (or Specified)."
-        return (0, 0)
+        return (0, 0, 0)
 
     print "\nRunning Performance Tests:\n"
 

--- a/avida-core/tests/analyze_resize_max_batches/config/instset-heads.cfg
+++ b/avida-core/tests/analyze_resize_max_batches/config/instset-heads.cfg
@@ -1,39 +1,27 @@
-INSTSET heads_default:hw_type=0
-
-# No-ops
-INST nop-A         # a
-INST nop-B         # b
-INST nop-C         # c
-
-# Flow control operations
-INST if-n-equ      # d
-INST if-less       # e
-INST if-label      # f
-INST mov-head      # g
-INST jmp-head      # h
-INST get-head      # i
-INST set-flow      # j
-
-# Single Argument Math
-INST shift-r       # k
-INST shift-l       # l
-INST inc           # m
-INST dec           # n
-INST push          # o
-INST pop           # p
-INST swap-stk      # q
-INST swap          # r 
-
-# Double Argument Math
-INST add           # s
-INST sub           # t
-INST nand          # u
-
-# Biological Operations
-INST h-copy        # v
-INST h-alloc       # w
-INST h-divide      # x
-
-# I/O and Sensory
-INST IO            # y
-INST h-search      # z
+nop-A      1   # a
+nop-B      1   # b
+nop-C      1   # c
+if-n-equ   1   # d
+if-less    1   # e
+pop        1   # f
+push       1   # g
+swap-stk   1   # h
+swap       1   # i
+shift-r    1   # j
+shift-l    1   # k
+inc        1   # l
+dec        1   # m
+add        1   # n
+sub        1   # o
+nand       1   # p
+IO         1   # q   Puts current contents of register and gets new.
+h-alloc    1   # r   Allocate as much memory as organism can use.
+h-divide   1   # s   Cuts off everything between the read and write heads
+h-copy     1   # t   Combine h-read and h-write
+h-search   1   # u   Search for matching template, set flow head & return info
+               #   #   if no template, move flow-head here, set size&offset=0.
+mov-head   1   # v   Move ?IP? head to flow control.
+jmp-head   1   # w   Move ?IP? head by fixed amount in CX.  Set old pos in CX.
+get-head   1   # x   Get position of specified head in CX.
+if-label   1   # y
+set-flow   1   # z   Move flow-head to address in ?CX?

--- a/avida-core/tests/analyze_resize_max_batches/test_list
+++ b/avida-core/tests/analyze_resize_max_batches/test_list
@@ -4,7 +4,7 @@
 args = -a                
 
 app = %(default_app)s            ; Application path to test
-nonzeroexit = disallow   ; Exit code handling (disallow, allow, or require)
+nonzeroexit = require    ; Exit code handling (disallow, allow, or require)
                          ;  disallow - treat non-zero exit codes as failures
                          ;  allow - all exit codes are acceptable
                          ;  require - treat zero exit codes as failures, useful

--- a/run_tests
+++ b/run_tests
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-python avida-core/tests/_testrunner/testrunner.py $@ ---testrunner-name=./run_tests
-
+python3 avida-core/tests/_testrunner/testrunner.py $@ ---testrunner-name=./run_tests


### PR DESCRIPTION
Python 2 was [sunset on Jan 1, 2020](https://www.python.org/doc/sunset-python-2/) and will become increasingly more likely to not be installed on users' and developers' machines. This PR updates the test runner script to Python 3 and fixes a broken test discovered along the way. 